### PR TITLE
Task 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ jspm_packages
 
 # esbuild directories
 .esbuild
+.env

--- a/authorization-service/.sample.env
+++ b/authorization-service/.sample.env
@@ -1,0 +1,1 @@
+github_user=TEST_PASSWORD

--- a/authorization-service/serverless.ts
+++ b/authorization-service/serverless.ts
@@ -1,0 +1,47 @@
+import type { AWS } from '@serverless/typescript';
+import basicAuthorizer from '@authorization-service/functions/basicAuthorizer';
+
+const serverlessConfiguration: AWS = {
+  service: 'shop-cloudx-authorization-service',
+  frameworkVersion: '3',
+  plugins: ['serverless-esbuild'],
+  useDotenv: true,
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs14.x',
+    region: 'us-east-2',
+    stage: 'dev',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+      shouldStartNameWithService: true,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
+    },
+  },
+  // import the function via paths
+  functions: { basicAuthorizer },
+  package: { individually: true },
+  custom: {
+    esbuild: {
+      bundle: true,
+      minify: false,
+      sourcemap: true,
+      exclude: ['aws-sdk'],
+      target: 'node14',
+      define: { 'require.resolve': undefined },
+      platform: 'node',
+      concurrency: 10,
+    },
+  },
+  resources: {
+    Outputs: {
+      AuthorizerFunctionARN: {
+        Value: { 'Fn::GetAtt': ['BasicAuthorizerLambdaFunction', 'Arn'] },
+      },
+    },
+  },
+};
+
+module.exports = serverlessConfiguration;

--- a/authorization-service/src/functions/basicAuthorizer/handler.spec.ts
+++ b/authorization-service/src/functions/basicAuthorizer/handler.spec.ts
@@ -1,0 +1,136 @@
+import { APIGatewayTokenAuthorizerEvent } from 'aws-lambda';
+import { mockedContext } from '../../../../__mocks__/context';
+import { main } from './handler';
+
+jest.mock('@middy/core', () => require('../../../../__mocks__/middy'));
+
+describe('basicAuthorizer handler', function () {
+  const env = process.env;
+  const mockedCallback = jest
+    .fn()
+    .mockImplementation((...args) => console.log(args));
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...env };
+    mockedCallback.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  it('verifies successful user exists', async () => {
+    process.env.testKey = 'testPassword';
+    const event: APIGatewayTokenAuthorizerEvent = {
+      type: 'TOKEN',
+      methodArn:
+        'arn:aws:execute-api:us-east-2:720608073116:uepb4rehl2/dev/GET/import',
+      authorizationToken: 'Basic dGVzdEtleT10ZXN0UGFzc3dvcmQ=',
+    };
+
+    await main(event, mockedContext, mockedCallback);
+    expect(mockedCallback).toHaveBeenCalled();
+    expect(mockedCallback).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        policyDocument: expect.objectContaining({
+          Statement: expect.arrayContaining([
+            expect.objectContaining({
+              Effect: 'Allow',
+            }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('verifies 401 on missing auth header', async () => {
+    const event: APIGatewayTokenAuthorizerEvent = {
+      type: 'TOKEN',
+      methodArn:
+        'arn:aws:execute-api:us-east-2:720608073116:uepb4rehl2/dev/GET/import',
+      authorizationToken: null,
+    };
+
+    await main(event, mockedContext, mockedCallback);
+    expect(mockedCallback).toHaveBeenCalled();
+    expect(mockedCallback).toHaveBeenCalledWith('Unauthorized');
+  });
+
+  it('verifies 403 when user does not exist', async () => {
+    process.env.testKey = 'testPassword';
+
+    const event: APIGatewayTokenAuthorizerEvent = {
+      type: 'TOKEN',
+      methodArn:
+        'arn:aws:execute-api:us-east-2:720608073116:uepb4rehl2/dev/GET/import',
+      authorizationToken: 'Basic YW5vdGhlclVzZXI9VEVTVF9QQVNTV09SRA==',
+    };
+
+    await main(event, mockedContext, mockedCallback);
+    expect(mockedCallback).toHaveBeenCalled();
+    expect(mockedCallback).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        policyDocument: expect.objectContaining({
+          Statement: expect.arrayContaining([
+            expect.objectContaining({
+              Effect: 'Deny',
+            }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('verifies 403 when password does not match', async () => {
+    process.env.testKey = 'testPassword';
+    const event: APIGatewayTokenAuthorizerEvent = {
+      type: 'TOKEN',
+      methodArn:
+        'arn:aws:execute-api:us-east-2:720608073116:uepb4rehl2/dev/GET/import',
+      authorizationToken: 'Basic dGVzdEtleT0xMjM0NTY3OA==',
+    };
+
+    await main(event, mockedContext, mockedCallback);
+    expect(mockedCallback).toHaveBeenCalled();
+    expect(mockedCallback).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        policyDocument: expect.objectContaining({
+          Statement: expect.arrayContaining([
+            expect.objectContaining({
+              Effect: 'Deny',
+            }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('verifies 403 when token is incomplete fails', async () => {
+    process.env.testKey = 'testPassword';
+    const event: APIGatewayTokenAuthorizerEvent = {
+      type: 'TOKEN',
+      methodArn:
+        'arn:aws:execute-api:us-east-2:720608073116:uepb4rehl2/dev/GET/import',
+      authorizationToken: 'Basic YW5vdGhl==',
+    };
+
+    await main(event, mockedContext, mockedCallback);
+    expect(mockedCallback).toHaveBeenCalled();
+    expect(mockedCallback).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        policyDocument: expect.objectContaining({
+          Statement: expect.arrayContaining([
+            expect.objectContaining({
+              Effect: 'Deny',
+            }),
+          ]),
+        }),
+      })
+    );
+  });
+});

--- a/authorization-service/src/functions/basicAuthorizer/handler.ts
+++ b/authorization-service/src/functions/basicAuthorizer/handler.ts
@@ -1,0 +1,63 @@
+import {
+  APIGatewayTokenAuthorizerEvent,
+  AuthResponse,
+  PolicyDocument,
+} from 'aws-lambda';
+
+const basicAuthorizer = async (
+  event: APIGatewayTokenAuthorizerEvent,
+  _,
+  callback
+): Promise<AuthResponse> => {
+  const headerToken = extractTokenFromHeader(event);
+
+  if (!headerToken) {
+    console.log({ headerToken });
+
+    callback('Unauthorized');
+    return;
+  }
+
+  if (!validateToken(headerToken)) {
+    console.log({ isValid: validateToken(headerToken) });
+    callback(null, {
+      principalId: 'user',
+      policyDocument: generatePolicy('Deny', event.methodArn),
+    });
+    return;
+  }
+
+  callback(null, {
+    principalId: '',
+    policyDocument: generatePolicy('Allow', event.methodArn),
+  });
+};
+
+const extractTokenFromHeader = (e: APIGatewayTokenAuthorizerEvent) => {
+  const header = e.authorizationToken;
+
+  if (header && header.split(' ')[0] === 'Basic') return header.split(' ')[1];
+  return null;
+};
+
+const validateToken = (token: string) => {
+  const decodedData = Buffer.from(token, 'base64').toString('binary');
+  const [user, password] = decodedData.split('=');
+  return !!process.env[user] && process.env[user] === password;
+};
+
+const generatePolicy = (effect: string, resource: string): PolicyDocument => {
+  const policyDocument = {} as PolicyDocument;
+  if (effect && resource) {
+    policyDocument.Version = '2012-10-17';
+    policyDocument.Statement = [];
+    const statementOne: any = {};
+    statementOne.Action = 'execute-api:Invoke';
+    statementOne.Effect = effect;
+    statementOne.Resource = resource;
+    policyDocument.Statement[0] = statementOne;
+  }
+  return policyDocument;
+};
+
+export const main = basicAuthorizer;

--- a/authorization-service/src/functions/basicAuthorizer/index.ts
+++ b/authorization-service/src/functions/basicAuthorizer/index.ts
@@ -1,0 +1,5 @@
+import { handlerPath } from '@libs/handler-resolver';
+
+export default {
+  handler: `${handlerPath(__dirname)}/handler.main`,
+};

--- a/authorization-service/src/functions/basicAuthorizer/mock.json
+++ b/authorization-service/src/functions/basicAuthorizer/mock.json
@@ -1,0 +1,5 @@
+{
+  "type": "TOKEN",
+  "methodArn": "arn:aws:execute-api:us-east-2:720608073116:uepb4rehl2/dev/GET/import",
+  "authorizationToken": "Basic YXJjaGVyM2NsOlRFU1RfUEFTU1dPUkQ="
+}

--- a/authorization-service/src/functions/index.ts
+++ b/authorization-service/src/functions/index.ts
@@ -1,0 +1,1 @@
+export { default as basicAuthorizer } from './basicAuthorizer';

--- a/import-service/serverless.ts
+++ b/import-service/serverless.ts
@@ -142,6 +142,19 @@ const serverlessConfiguration: AWS & Lift = {
           },
         },
       },
+      GatewayResponse: {
+        Type: 'AWS::ApiGateway::GatewayResponse',
+        Properties: {
+          ResponseParameters: {
+            'gatewayresponse.header.Access-Control-Allow-Origin': "'*'",
+            'gatewayresponse.header.Access-Control-Allow-Headers': "'*'",
+          },
+          ResponseType: 'DEFAULT_4XX',
+          RestApiId: {
+            Ref: 'ApiGatewayRestApi',
+          },
+        },
+      },
     },
   },
   constructs: {

--- a/import-service/src/functions/importProductsFile/index.ts
+++ b/import-service/src/functions/importProductsFile/index.ts
@@ -8,6 +8,7 @@ export default {
         method: 'get',
         path: 'import',
         cors: true,
+        authorizer: '${param:authArn}',
         request: {
           parameters: {
             querystrings: {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Product Service",
   "main": "store/serverless.ts",
   "scripts": {
-    "task6:print": "sls print --service=import-service",
-    "task6:local:catalog-batch-process": "sls invoke local --service=import-service -f catalogItemsQueueWorker --path src/functions/catalogBatchProcess/mock.json",
+    "task7:print": "sls print --service=authorization-service",
+    "task7:local:basicAuthorizer": "sls invoke local --service=authorization-service -f basicAuthorizer --path src/functions/basicAuthorizer/mock.json",
+    "authorization-service:setup": "sls deploy --service=authorization-service",
+    "authorization-service:remove": "sls remove --service=authorization-service",
     "cloudformation:setup": "sls deploy",
     "cloudformation:remove": "sls remove",
     "dynamodb:remove": "sls remove --service=dynamodb",

--- a/serverless-compose.yml
+++ b/serverless-compose.yml
@@ -2,6 +2,9 @@ services:
   dynamodb:
     path: dynamodb
 
+  authorization-service:
+    path: authorization-service
+
   store:
     path: store
     params:
@@ -17,3 +20,4 @@ services:
       stocksTableResource: ${dynamodb.StocksTableResource}
       productsTable: ${dynamodb.ProductsTableName}
       stocksTable: ${dynamodb.StocksTableName}
+      authArn: ${authorization-service.AuthorizerFunctionARN}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,8 @@
     "store/serverless.ts",
     "import-service/src/**/*.ts",
     "import-service/serverless.ts",
+    "authorization-service/src/**/*.ts",
+    "authorization-service/serverless.ts",
     "libs/**/*.ts",
     "models/**/*.ts"
   ],

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -6,7 +6,8 @@
       "@models/*": ["models/*"],
       "@services/*": ["services/*"],
       "@store/*": ["store/src/*"],
-      "@import-service/*": ["import-service/src/*"]
+      "@import-service/*": ["import-service/src/*"],
+      "@authorization-service/*": ["authorization-service/src/*"]
     }
   }
 }


### PR DESCRIPTION
Lambda authorizer implementation
* Created new resources for authorization-service
* Created new lambda to be triggered as custom authorization for endpoint

### Task 7.1
- For new serverless config check files
  - `serverless-compose.yml`
  - `authorization-service/serverless.ts`
- For new lambda review the files at `authorization-service/src/functions/basicAuthorizer`

### Task 7.2 and 7.3
- For new serverless config check files
  - `import-service/src/functions/importProductsFile/index.ts`
  - `import-service/serverless.ts`

To test functionality at [https://dj96t9o95409e.cloudfront.net/admin/products](https://dj96t9o95409e.cloudfront.net/admin/products) and search for "Import Products CSV". Use the file `test-product.csv` in the repo for reference.

### Additional tasks
- +30 - Client application should display alerts for the responses in 401 and 403 HTTP statuses.
  - Go to [https://dj96t9o95409e.cloudfront.net/admin/products](https://dj96t9o95409e.cloudfront.net/admin/products) and use the import file button
  - Remove any local storage item called `authorization_token` to get 401 error
  - Add a local storage item called `authorization_token` with any value to get 403 error
  - Add a local storage item called `authorization_token` with value `YXJjaGVyM2NsPVRFU1RfUEFTU1dPUkQ=` to successfully submit the file